### PR TITLE
Serves static assets for Swagger UI

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "morgan": "^1.10.0",
         "pg": "^8.10.0",
         "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-dist": "^5.26.2",
         "swagger-ui-express": "^4.6.3"
       },
       "devDependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
     "morgan": "^1.10.0",
     "pg": "^8.10.0",
     "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-dist": "^5.26.2",
     "swagger-ui-express": "^4.6.3"
   },
   "devDependencies": {

--- a/backend/server.js
+++ b/backend/server.js
@@ -108,10 +108,33 @@ app.use(express.json());
 
 
 // Swagger documentation
+const swaggerUiAssetPath = require("swagger-ui-dist").getAbsoluteFSPath();
+app.use('/api-docs', express.static(swaggerUiAssetPath));
+app.get('/api-docs/swagger-ui.css', (req, res) => {
+  const fs = require('fs');
+  const cssPath = path.join(swaggerUiAssetPath, 'swagger-ui.css');
+  
+  res.setHeader('Content-Type', 'text/css');
+  
+  if (fs.existsSync(cssPath)) {
+    res.sendFile(cssPath);
+  } else {
+    // Fallback CSS if file doesn't exist
+    res.send(`
+      .swagger-ui .topbar {
+        background-color: #2c3e50;
+      }
+      .swagger-ui .info .title {
+        color: #2c3e50;
+      }
+    `);
+  }
+});
+
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec, { 
   explorer: true ,
   customCssUrl: '/api-docs/swagger-ui.css',
-    swaggerOptions: {
+  swaggerOptions: {
     url: null, 
   }
 }));


### PR DESCRIPTION
Enables serving of Swagger UI's static assets directly from the `swagger-ui-dist` package.

- Includes a fallback  debug CSS to if the default CSS is unavailable.